### PR TITLE
Add trailing comma to fix ESLint comma-dangle

### DIFF
--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -27,6 +27,6 @@ module.exports = {
   rules: {
     "quotes": ["error", "double"],
     "import/no-unresolved": 0,
-    "indent": ["error", 2]
+    "indent": ["error", 2],
   },
 };


### PR DESCRIPTION
### Description
The TypeScript template for Firebase Functions does not pass the ESLint rule `comma-dangle`. Adding a comma to fix the issue.

Issue observed by creating a new project with Firebase Functions.
1. `firebase init`
2. Select functions
3. Select TypeScript
4. Enable ESLint to catch bugs and enforce style.

Without this comma, the lint reports an error when running the linter.

```
$ npm --prefix "functions" run lint 

> lint
> eslint --ext .js,.ts .


/Users/cartland/github/cartland/leaky-bucket/functions/.eslintrc.js
  30:27  error  Missing trailing comma  comma-dangle

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

### Scenarios Tested

After adding the comma to a Firebase Functions project, the linter doesn't show an error.

```
$ npm --prefix "functions" run lint

> lint
> eslint --ext .js,.ts .
```

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
